### PR TITLE
new apis for quick summary; seperated memories

### DIFF
--- a/src/main/java/com/example/AutoDocX/controller/AgentController.java
+++ b/src/main/java/com/example/AutoDocX/controller/AgentController.java
@@ -4,6 +4,7 @@ import com.example.AutoDocX.service.ApiResponse;
 import com.example.AutoDocX.service.Agent;
 import com.example.AutoDocX.service.GeneralSummaryAgent;
 import com.example.AutoDocX.service.DocumentationAgent;
+import com.example.AutoDocX.service.SummaryAgent;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -18,6 +19,7 @@ public class AgentController {
     private final Agent agent;
     private final GeneralSummaryAgent generalSummaryAgent;
     private final DocumentationAgent documentationAgent;
+    private final SummaryAgent summaryAgent;
 
     @PostMapping("/get-response")
     public ResponseEntity<ApiResponse<String>> getResponse(@RequestBody AgentRequest request) {
@@ -33,8 +35,19 @@ public class AgentController {
     @PostMapping("/run-summary")
     public ResponseEntity<ApiResponse<String>> runSummary(@RequestBody AgentRequest request) {
         try {
-            String summary = generalSummaryAgent.run(request.getGitUrl(), request.getBranch());
+            String summary = summaryAgent.run(request.getGitUrl(), request.getBranch(), request.getUserPrompt(), 0);
             return ResponseEntity.ok(new ApiResponse<>("SUCCESS", "Summary agent finished.", summary));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ApiResponse<>("ERROR", e.getMessage(), null));
+        }
+    }
+
+    @PostMapping("/run-general-summary")
+    public ResponseEntity<ApiResponse<String>> runGeneralSummary(@RequestBody AgentRequest request) {
+        try {
+            String summary = generalSummaryAgent.run(request.getGitUrl(), request.getBranch());
+            return ResponseEntity.ok(new ApiResponse<>("SUCCESS", "General summary agent finished.", summary));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new ApiResponse<>("ERROR", e.getMessage(), null));

--- a/src/main/java/com/example/AutoDocX/service/Agent.java
+++ b/src/main/java/com/example/AutoDocX/service/Agent.java
@@ -108,7 +108,7 @@ public class Agent {
             if (result.getModelFinishReason() == ModelFinishReason.OUTPUT_ERROR ||
                     result.getModelFinishReason() == ModelFinishReason.INPUT_ERROR) {
                 currentResponse = "Model stopped due to " + result.getModelFinishReason();
-                session.getMemory().getEpisodic().addEntry("error:model_finish", currentResponse);
+                session.getMemory().getSumAgentLog().addEntry("error:model_finish", currentResponse);
                 break;
             }
 
@@ -119,7 +119,7 @@ public class Agent {
                 break ;
             }
 
-            session.getMemory().getEpisodic().addEntry("model", currentResponse);
+            session.getMemory().getSumAgentLog().addEntry("model", currentResponse);
             break;
         }
 
@@ -130,7 +130,7 @@ public class Agent {
      * Centralized tool call handling. Also stores tool results into relevant memory stores.
      */
     private String handleToolCall(String tool, Map<String, Object> param, ClonedRepo repo, Graph graph, Session session) {
-        ToolExecutionContext context = new ToolExecutionContext(repo, graph, session);
+        ToolExecutionContext context = new ToolExecutionContext(repo, graph, session, session.getMemory().getSumAgentLog());
         return mcpToolKit.executeTool(tool, param, context);
     }
 
@@ -199,7 +199,7 @@ public class Agent {
         }
 
         // === Episodic Memory (recent only, for flow) ===
-        List<Memory.MemoryEntry> episodicEntries = memory.getEpisodic().getEntries();
+        List<Memory.MemoryEntry> episodicEntries = memory.getSumAgentLog().getEntries();
         if (!episodicEntries.isEmpty()) {
             StringBuilder episodicSection = new StringBuilder("LOG MEMORY:\n");
             int start = Math.max(0, episodicEntries.size() - EPISODIC_HISTORY_FOR_PROMPT);
@@ -225,7 +225,7 @@ public class Agent {
 
     private String getFinalResponse(Memory memory) {
         // Prefer the last final_answer in episodic memory
-        List<Memory.MemoryEntry> episodic = memory.getEpisodic().getEntries();
+        List<Memory.MemoryEntry> episodic = memory.getSumAgentLog().getEntries();
         for (int i = episodic.size() - 1; i >= 0; i--) {
             Memory.MemoryEntry e = episodic.get(i);
             if ("model".equals(e.getQuery())) {

--- a/src/main/java/com/example/AutoDocX/service/DocumentationAgent.java
+++ b/src/main/java/com/example/AutoDocX/service/DocumentationAgent.java
@@ -68,7 +68,7 @@ public class DocumentationAgent {
         Graph graph;
         try { graph = repoHandler.getGraph(repo); } catch (Exception e) { return "Graph load failed: " + e.getMessage(); }
 
-        ToolExecutionContext ctx = new ToolExecutionContext(repo, graph, session);
+        ToolExecutionContext ctx = new ToolExecutionContext(repo, graph, session, session.getMemory().getDocAgentLog());
 
         int iterations = 0;
         int maxIterations = (iterationLimit == null || iterationLimit <= 0) ? DEFAULT_MAX_ITERATIONS : iterationLimit;
@@ -82,7 +82,7 @@ public class DocumentationAgent {
             } catch (Exception e) {
                 String msg = "Model invocation error: " + e.getMessage();
                 System.err.println("WARN (DocumentationAgent): " + msg);
-                session.getMemory().getEpisodic().addEntry("error:model_call", msg);
+                session.getMemory().getDocAgentLog().addEntry("error:model_call", msg);
                 break;
             }
 
@@ -90,12 +90,12 @@ public class DocumentationAgent {
                 result.getModelFinishReason() == ModelFinishReason.INPUT_ERROR) {
                 String msg = "Model stopped due to " + result.getModelFinishReason();
                 System.err.println("WARN (DocumentationAgent): " + msg);
-                session.getMemory().getEpisodic().addEntry("error:model_finish", msg);
+                session.getMemory().getDocAgentLog().addEntry("error:model_finish", msg);
                 break; // emergency stop
             }
             if (result.getText().isPresent()) {
                 String assistant = result.getText().get();
-                session.getMemory().getEpisodic().addEntry("doc_agent.assistant", assistant);
+                session.getMemory().getDocAgentLog().addEntry("doc_agent.assistant", assistant);
             }
 
             if (!result.getToolCalls().isEmpty()) {
@@ -133,7 +133,7 @@ public class DocumentationAgent {
                                 if (planResult != null && !planResult.isEmpty()) {
                                     toolLogValue += " Result: " + planResult.substring(0, Math.min(200, planResult.length())) + "... (stored in " + key + ")";
                                 }
-                                session.getMemory().getEpisodic().addEntry(toolLogKey, toolLogValue);
+                                session.getMemory().getDocAgentLog().addEntry(toolLogKey, toolLogValue);
                                 break;
                             }
                             default: {
@@ -249,8 +249,8 @@ STEPS:
             context.append("EXISTING SUMMARY:\n").append(memory.getSummary().toString()).append("\n\n");
         }
 
-        if (memory.getEpisodic() != null && !memory.getEpisodic().isEmpty()) {
-            context.append("LOG:\n").append(memory.getEpisodic().toString(DEFAULT_MAX_ITERATIONS * 2)).append("\n\n");
+        if (memory.getDocAgentLog() != null && !memory.getDocAgentLog().isEmpty()) {
+            context.append("LOG:\n").append(memory.getDocAgentLog().toString(DEFAULT_MAX_ITERATIONS * 2)).append("\n\n");
         }
 
         context.append("USER PROMPT:\n").append(userPrompt == null ? "" : userPrompt).append("\n\n");

--- a/src/main/java/com/example/AutoDocX/service/GeneralSummaryAgent.java
+++ b/src/main/java/com/example/AutoDocX/service/GeneralSummaryAgent.java
@@ -78,7 +78,7 @@ public class GeneralSummaryAgent {
         } catch (Exception e) {
             return "Error loading graph: " + e.getMessage();
         }
-        ToolExecutionContext toolExecutionContext = new ToolExecutionContext(repo, graph, session);
+        ToolExecutionContext toolExecutionContext = new ToolExecutionContext(repo, graph, session, session.getMemory().getSumAgentLog());
 
         if (!session.isInitialStructureLogged()) {
             session.getMemory().getStructure().addEntry("graph_structure", graph.toString());
@@ -90,13 +90,12 @@ public class GeneralSummaryAgent {
         int maxIterations = (iterationLimit == null || iterationLimit <= 0) ? DEFAULT_MAX_ITERATIONS : iterationLimit;
         while (iterations++ < maxIterations) {
             List<Tool> summaryTools = mcpToolKit.getExplorationTools();
-            String basePrompt = "Explore the codebase breadth-first. Use tools in batches. After finishing tool calls, call update_understanding with a concise plan: current understanding + next actions.";
+            String basePrompt = "Explore the codebase to provide a project-level summary. Your primary goal is breadth-first coverage of all important components.";
             String loopPrompt = (focusPrompt != null && !focusPrompt.isBlank())
-                    ? basePrompt + "\nFOCUS: " + focusPrompt
-                    : basePrompt;
-            List<Content> contents = buildLoopContent(session.getMemory(), loopPrompt);
+                ? basePrompt + "\nUSER QUERY/FOCUS: " + focusPrompt
+                : basePrompt;
 
-            // Request/response logging centralized in GeminiModel
+            List<Content> contents = buildLoopContent(session.getMemory(), loopPrompt);
 
             SendMessageResult result;
             try {
@@ -104,22 +103,25 @@ public class GeneralSummaryAgent {
             } catch (Exception e) {
                 String msg = "Model invocation error: " + e.getMessage();
                 logger.warn("SUM[{}] {}", runId, msg);
-                session.getMemory().getEpisodic().addEntry("error:model_call", msg);
+                session.getMemory().getSumAgentLog().addEntry("error:model_call", msg);
                 break;
             }
-            // Response summary logged centrally in GeminiModel
 
             if (!result.getToolCalls().isEmpty()) {
                 for (ToolCallData fc : result.getToolCalls()) {
                     logger.info("SUM[{}] Executing tool: {} with args: {}", runId, fc.getName(), fc.getArgs());
                     mcpToolKit.executeTool(fc.getName(), fc.getArgs(), toolExecutionContext);
                 }
-                // continue loop to let the model process tool results; understanding update is required by prompt
-                continue;
+                continue; // let model process tool results in next loop
             }
 
-            if (result.getText().isPresent()) {
-                session.getMemory().getEpisodic().addEntry("model", result.getText().get());
+            // End early if no tools are called
+            if (result.getToolCalls().isEmpty()) {
+                if (result.getText().isPresent()) {
+                    session.getMemory().getSumAgentLog().addEntry("model", result.getText().get());
+                    return result.getText().get();
+                }
+                break;
             }
         }
 

--- a/src/main/java/com/example/AutoDocX/service/McpToolKit.java
+++ b/src/main/java/com/example/AutoDocX/service/McpToolKit.java
@@ -290,23 +290,21 @@ public class McpToolKit {
                     // handled internally; nothing to store synchronously here
                     break;
                 case "update_understanding":
-                    context.getSession().getMemory().getSummary().replaceEntry("understanding", result);
-                    context.getSession().getMemory().getEpisodic().addEntry("model:tool_call:" + toolName + "(" + "..." + ")", "Success");
-                    return result;
-                default:
-                    System.out.println("WARNING: unknown tool: " + toolName + " (" + paramForMemory + ")");
-                    break;
-            }
-            context.getSession().getMemory().getEpisodic().addEntry("model:tool_call:" + toolName + "(" + paramForMemory + ")", "Success");
-        } catch (Exception e) {
-            result = e.getClass().getSimpleName() + ": " + e.getMessage();
-            System.err.println("DEBUG: Tool execution failed for " + toolName + " with param " + paramForMemory + ". Error: " + e.getMessage());
-            context.getSession().getMemory().getEpisodic().addEntry("tool_call:" + toolName + "(" + paramForMemory + ")", result);
-        }
-        return result;
+            context.getSession().getMemory().getSummary().replaceEntry("understanding", result);
+            context.getEpisodicMemory().addEntry("model:tool_call:" + toolName + "(" + "..." + ")", "Success");
+            return result;
+        default:
+            System.out.println("WARNING: unknown tool: " + toolName + " (" + paramForMemory + ")");
+            break;
     }
-
-    private String execute(String toolName, Map<String, Object> paramsMap, ToolExecutionContext context) throws Exception {
+    context.getEpisodicMemory().addEntry("model:tool_call:" + toolName + "(" + paramForMemory + ")", "Success");
+} catch (Exception e) {
+    result = e.getClass().getSimpleName() + ": " + e.getMessage();
+    System.err.println("DEBUG: Tool execution failed for " + toolName + " with param " + paramForMemory + ". Error: " + e.getMessage());
+    context.getSession().getMemory().getDocAgentLog().addEntry("tool_call:" + toolName + "(" + paramForMemory + ")", result);
+}
+return result;
+}    private String execute(String toolName, Map<String, Object> paramsMap, ToolExecutionContext context) throws Exception {
         switch (toolName) {
             case "get_code": {
                 String nodeId = (String) paramsMap.get("node_id");

--- a/src/main/java/com/example/AutoDocX/service/Memory.java
+++ b/src/main/java/com/example/AutoDocX/service/Memory.java
@@ -22,7 +22,8 @@ public class Memory {
     private static final int MAX_STORE_CHARS = 5000; // change as needed
     private static final String TRUNCATION_NOTICE = "... [TRUNCATED]";
 
-    private final MemoryStore episodic = new MemoryStore("Episodic");
+    private final MemoryStore sumAgentLog = new MemoryStore("Summary Log");
+    private final MemoryStore docAgentLog = new MemoryStore("Documentation Log");
     private final MemoryStore code = new MemoryStore("Code");
     private final MemoryStore structure = new MemoryStore("Structure");
     private final MemoryStore summary = new MemoryStore("Summary");
@@ -33,7 +34,8 @@ public class Memory {
      */
     public String prettyPrintAll(int latestN) {
         StringBuilder sb = new StringBuilder();
-        sb.append("=== Episodic Memory ===\n").append(episodic.toString(latestN)).append("\n\n");
+        sb.append("=== Summary Episodic Memory ===\n").append(sumAgentLog.toString(latestN)).append("\n\n");
+        sb.append("=== Documentation Episodic Memory ===\n").append(docAgentLog.toString(latestN)).append("\n\n");
         sb.append("=== Code Memory ===\n").append(code.toString(latestN)).append("\n\n");
         sb.append("=== Structure Memory ===\n").append(structure.toString(latestN)).append("\n\n");
         sb.append("=== Summary Memory ===\n").append(summary.toString(latestN)).append("\n\n");

--- a/src/main/java/com/example/AutoDocX/service/SummaryAgent.java
+++ b/src/main/java/com/example/AutoDocX/service/SummaryAgent.java
@@ -5,7 +5,6 @@ import com.example.AutoDocX.model.repo.Model;
 import com.example.AutoDocX.model.repo.SendMessageResult;
 import com.example.AutoDocX.model.repo.ToolCallData;
 import com.example.AutoDocX.parser.model.Graph;
-import com.example.AutoDocX.parser.model.GraphNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.genai.types.Content;
 import com.google.genai.types.Part;
@@ -18,7 +17,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 public class SummaryAgent {
@@ -73,7 +71,7 @@ public class SummaryAgent {
         } catch (Exception e) {
             return "Error loading graph: " + e.getMessage();
         }
-        ToolExecutionContext toolExecutionContext = new ToolExecutionContext(repo, graph, session);
+        ToolExecutionContext toolExecutionContext = new ToolExecutionContext(repo, graph, session, session.getMemory().getSumAgentLog());
 
         if (!session.isInitialStructureLogged()) {
             session.getMemory().getStructure().addEntry("graph_structure", graph.toString());
@@ -83,7 +81,7 @@ public class SummaryAgent {
 
         String runId = UUID.randomUUID().toString();
         int iterations = 0;
-        int maxIterations = (iterationLimit == null || iterationLimit <= 0) ? DEFAULT_MAX_ITERATIONS : iterationLimit;
+        int maxIterations = (iterationLimit == null || iterationLimit < 0) ? DEFAULT_MAX_ITERATIONS : iterationLimit;
 
         while (iterations++ < maxIterations) {
             List<Tool> summaryTools = mcpToolKit.getExplorationTools();
@@ -100,7 +98,7 @@ public class SummaryAgent {
             } catch (Exception e) {
                 String msg = "Model invocation error: " + e.getMessage();
                 logger.warn("SUM[{}] {}", runId, msg);
-                session.getMemory().getEpisodic().addEntry("error:model_call", msg);
+                session.getMemory().getSumAgentLog().addEntry("error:model_call", msg);
                 break;
             }
 
@@ -115,7 +113,7 @@ public class SummaryAgent {
             // End early if no tools are called
             if (result.getToolCalls().isEmpty()) {
                 if (result.getText().isPresent()) {
-                    session.getMemory().getEpisodic().addEntry("model", result.getText().get());
+                    session.getMemory().getSumAgentLog().addEntry("model", result.getText().get());
                     return result.getText().get();
                 }
                 break;

--- a/src/main/java/com/example/AutoDocX/service/ToolExecutionContext.java
+++ b/src/main/java/com/example/AutoDocX/service/ToolExecutionContext.java
@@ -2,18 +2,14 @@ package com.example.AutoDocX.service;
 
 import com.example.AutoDocX.model.ClonedRepo;
 import com.example.AutoDocX.parser.model.Graph;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class ToolExecutionContext {
     private final ClonedRepo repo;
     private final Graph graph;
     private final Session session;
-
-    public ToolExecutionContext(ClonedRepo repo, Graph graph, Session session) {
-        this.repo = repo;
-        this.graph = graph;
-        this.session = session;
-    }
-
+    private final Memory.MemoryStore episodicMemory;
 }


### PR DESCRIPTION
This pull request refactors the agent memory management system to improve separation between summary and documentation agent logs, and updates the controller endpoints to support both summary and general summary agents. The main changes include introducing dedicated memory stores for different agent types, updating all relevant service classes to use these stores, and adjusting the controller to provide clearer API endpoints for summary operations.

**Agent Memory Management Refactor:**

* Introduced two new memory stores in the `Memory` class: `sumAgentLog` for summary agent logs and `docAgentLog` for documentation agent logs, replacing the previous shared `episodic` memory store. All references in agent and toolkit code have been updated to use the appropriate log. (`src/main/java/com/example/AutoDocX/service/Memory.java`, `src/main/java/com/example/AutoDocX/service/Agent.java`, `src/main/java/com/example/AutoDocX/service/DocumentationAgent.java`, `src/main/java/com/example/AutoDocX/service/GeneralSummaryAgent.java`, `src/main/java/com/example/AutoDocX/service/SummaryAgent.java`, `src/main/java/com/example/AutoDocX/service/McpToolKit.java`) [[1]](diffhunk://#diff-4b7ce9ee868067cff8cf2a30343608d40b11cc8ea26f1914d530057a0ffe0cf1L25-R26) [[2]](diffhunk://#diff-4b7ce9ee868067cff8cf2a30343608d40b11cc8ea26f1914d530057a0ffe0cf1L36-R38) [[3]](diffhunk://#diff-1e72ea703a77191e630382e78376d0a88fa8897f80f019723bb8db31f3468facL111-R111) [[4]](diffhunk://#diff-1e72ea703a77191e630382e78376d0a88fa8897f80f019723bb8db31f3468facL122-R122) [[5]](diffhunk://#diff-1e72ea703a77191e630382e78376d0a88fa8897f80f019723bb8db31f3468facL202-R202) [[6]](diffhunk://#diff-1e72ea703a77191e630382e78376d0a88fa8897f80f019723bb8db31f3468facL228-R228) [[7]](diffhunk://#diff-84e18ead51cf39a3a2116d2c82dee885e637e6a7004238158858d4058fb076a6L71-R71) [[8]](diffhunk://#diff-84e18ead51cf39a3a2116d2c82dee885e637e6a7004238158858d4058fb076a6L85-R98) [[9]](diffhunk://#diff-84e18ead51cf39a3a2116d2c82dee885e637e6a7004238158858d4058fb076a6L136-R136) [[10]](diffhunk://#diff-84e18ead51cf39a3a2116d2c82dee885e637e6a7004238158858d4058fb076a6L252-R253) [[11]](diffhunk://#diff-e93daa13b44e778daecaf8e16244d53ef212d666f4c6964da328b980092b3d2cL81-R81) [[12]](diffhunk://#diff-e93daa13b44e778daecaf8e16244d53ef212d666f4c6964da328b980092b3d2cL93-R124) [[13]](diffhunk://#diff-017abf1df504ff1fad39f72f164cf979e710ec79cc1da470d7da085e19da5ddfL76-R74) [[14]](diffhunk://#diff-017abf1df504ff1fad39f72f164cf979e710ec79cc1da470d7da085e19da5ddfL103-R101) [[15]](diffhunk://#diff-017abf1df504ff1fad39f72f164cf979e710ec79cc1da470d7da085e19da5ddfL118-R116) [[16]](diffhunk://#diff-d380b7c49ec0c11910d2577cc11d792061e9da9d4dc50308e24f7c5b4f2ea69eL294-R307)

**Controller and API Improvements:**

* Added a new `SummaryAgent` dependency to `AgentController` and introduced a `/run-general-summary` endpoint for general summary operations, clarifying the distinction between summary and general summary agents. The `/run-summary` endpoint now uses the new `SummaryAgent` with support for user prompts and iteration limits. (`src/main/java/com/example/AutoDocX/controller/AgentController.java`) [[1]](diffhunk://#diff-8579a9a921afda25fb535c50b933246aa943c78802cd6c6c6687a51fefb3ee16R7) [[2]](diffhunk://#diff-8579a9a921afda25fb535c50b933246aa943c78802cd6c6c6687a51fefb3ee16R22) [[3]](diffhunk://#diff-8579a9a921afda25fb535c50b933246aa943c78802cd6c6c6687a51fefb3ee16L36-R56)

**Prompt and Tool Execution Logic:**

* Updated agent and summary agent prompt logic to clarify user queries and focus, and improved early termination behavior when no tools are called. (`src/main/java/com/example/AutoDocX/service/GeneralSummaryAgent.java`, `src/main/java/com/example/AutoDocX/service/SummaryAgent.java`) [[1]](diffhunk://#diff-e93daa13b44e778daecaf8e16244d53ef212d666f4c6964da328b980092b3d2cL93-R124) [[2]](diffhunk://#diff-017abf1df504ff1fad39f72f164cf979e710ec79cc1da470d7da085e19da5ddfL86-R84)

**Code Cleanup:**

* Removed unused imports and streamlined code in `SummaryAgent.java`. (`src/main/java/com/example/AutoDocX/service/SummaryAgent.java`) [[1]](diffhunk://#diff-017abf1df504ff1fad39f72f164cf979e710ec79cc1da470d7da085e19da5ddfL8) [[2]](diffhunk://#diff-017abf1df504ff1fad39f72f164cf979e710ec79cc1da470d7da085e19da5ddfL21)